### PR TITLE
Implement auto geolocation based on browser geolocation, Implements #9

### DIFF
--- a/src/services/rki.service.js
+++ b/src/services/rki.service.js
@@ -28,6 +28,17 @@ class RkiService {
     }
   }
 
+  async getDistrictName ({ latitude, longitude }) {
+    const url = `https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/RKI_Landkreisdaten/FeatureServer/0/query?where=1%3D1&outFields=RS,GEN,cases7_bl_per_100k,cases7_per_100k,BL&geometry=${longitude.toFixed(3)}%2C${latitude.toFixed(3)}&geometryType=esriGeometryPoint&inSR=4326&spatialRel=esriSpatialRelWithin&returnGeometry=false&outSR=4326&f=json`
+    const result = await axios.get(url)
+    if (result.error) {
+      console.error(result.error)
+    } else {
+      const { features } = result.data
+      return features.length > 0 ? features[0].attributes.GEN.toString() : null
+    }
+  }
+
 }
 
 export const rkiService = new RkiService()

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -15,6 +15,7 @@
 <script>
 import DocHead from '@/components/DocHead.vue'
 import Widget from '@/components/Widget.vue'
+import { rkiService } from '@/services/rki.service'
 
 export default {
   name: 'Home',
@@ -41,17 +42,49 @@ export default {
       selected: null
     }
   },
-  mounted() {
-    if(this.id) {
+  async mounted () {
+    if (this.id) {
       this.selected = this.id
-      localStorage.setItem('landkreis', this.selected)
+      this.persistDistrict()
     } else {
       this.selected = localStorage.getItem('landkreis')
     }
 
-    if(this.selected) {
+    if (this.selected) {
+      this.routeToDistrictSpecificAmpelWidget()
+      return
+    }
+    if (!("geolocation" in navigator)) {
+      this.routeToConfigPage()
+      return
+    }
+    await navigator.geolocation.getCurrentPosition(async (currentPositionOfUser) => {
+      const districtName = await rkiService.getDistrictName(currentPositionOfUser.coords)
+      if (!districtName) {
+        this.routeToConfigPage()
+      }
+      const areas = await rkiService.getAreas()
+      this.selected = areas.find(area => {
+        if (!area) {
+          return false
+        }
+        return area.attributes.GEN === districtName
+        }
+      ).attributes.OBJECTID
+      this.persistDistrict()
+      this.routeToDistrictSpecificAmpelWidget()
+    }, () => {
+      this.routeToConfigPage()
+    })
+  },
+  methods: {
+    persistDistrict() {
+      localStorage.setItem('landkreis', this.selected)
+    },
+    routeToDistrictSpecificAmpelWidget() {
       this.$router.push('/lkr/' + this.selected)
-    } else {
+    },
+    routeToConfigPage() {
       this.$router.push('/config')
     }
   }


### PR DESCRIPTION
Die automatische Zuordnung eines Landkreises erfolgt, wenn
- Der Browser des Nutzers Geolokalisierung unterstützt.
- Der Nutzer dies zulässt.

Ich habe mit diesem Chrome [Plugin](https://chrome.google.com/webstore/detail/location-guard/cfohepagpmnodfdmjliccbbigdkfcgia?utm_source=chrome-ntp-icon) Standorte außerhalb Deutschlands getestet -> wie erwartet keine Lokalisierung.

Auf einem Mobilgerät kann ich es nicht testen.